### PR TITLE
ASROUTER-92:Support setting port speed in ONP plugin

### DIFF
--- a/ET2500/vpp-24.02/src/plugins/onp/api/api.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/api/api.c
@@ -243,6 +243,33 @@ vl_api_onp_show_counters_t_handler (vl_api_onp_show_counters_t *mp)
   vec_free (pool_stat);
 }
 
+static void
+vl_api_onp_set_port_speed_t_handler(vl_api_onp_set_port_speed_t* mp) {
+  onp_main_t* om = onp_get_main();
+  u32 sw_if_index = ntohl(mp->sw_if_index);
+  u32 port_speed = ntohl(mp->port_speed);
+  vlib_main_t* vm = vlib_get_main();
+  onp_pktio_t* pktio;
+  int rv = 1;
+
+  for (pktio = (om->onp_pktios); pktio < ((om->onp_pktios) + ((om->onp_pktios) ? __vec_len((void*)(om->onp_pktios)) : 0)); pktio++) {
+    if (pktio->sw_if_index == sw_if_index)
+    {
+      rv = 0;
+      break;
+    }
+  }
+
+  cnxk_pktio_link_info_t link_info = {};
+  cnxk_drv_pktio_link_info_get(vm, pktio->cnxk_pktio_index, &link_info);
+  if (link_info.speed != port_speed) {
+    link_info.speed = port_speed;
+    cnxk_drv_pktio_link_info_set(vm, pktio->cnxk_pktio_index, &link_info);
+  }
+
+  ONP_REPLY_MACRO(VL_API_ONP_SET_PORT_SPEED_REPLY, onp_set_port_speed,);
+}
+
 #include <onp/api/onp.api.c>
 
 static clib_error_t *

--- a/ET2500/vpp-24.02/src/plugins/onp/api/api.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/api/api.c
@@ -252,6 +252,8 @@ vl_api_onp_set_port_speed_t_handler(vl_api_onp_set_port_speed_t* mp) {
   onp_pktio_t* pktio;
   int rv = 1;
 
+  VALIDATE_SW_IF_INDEX(mp);
+
   for (pktio = (om->onp_pktios); pktio < ((om->onp_pktios) + ((om->onp_pktios) ? __vec_len((void*)(om->onp_pktios)) : 0)); pktio++) {
     if (pktio->sw_if_index == sw_if_index)
     {
@@ -266,6 +268,8 @@ vl_api_onp_set_port_speed_t_handler(vl_api_onp_set_port_speed_t* mp) {
     link_info.speed = port_speed;
     cnxk_drv_pktio_link_info_set(vm, pktio->cnxk_pktio_index, &link_info);
   }
+
+  BAD_SW_IF_INDEX_LABEL;
 
   ONP_REPLY_MACRO(VL_API_ONP_SET_PORT_SPEED_REPLY, onp_set_port_speed,);
 }

--- a/ET2500/vpp-24.02/src/plugins/onp/api/api_test.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/api/api_test.c
@@ -141,6 +141,24 @@ vl_api_onp_show_counters_reply_t_handler (vl_api_onp_show_counters_reply_t *mp)
   vam->result_ready = 1;
 }
 
+static int
+api_onp_set_port_speed(vat_main_t* vam) {
+  vl_api_onp_set_port_speed_t* mp;
+  u32 msg_size = sizeof(*mp);
+  int ret;
+
+  vam->result_ready = 0;
+  mp = vl_msg_api_alloc_as_if_client(msg_size);
+
+  M(ONP_SET_PORT_SPEED, mp);
+
+  /* send it... */
+  S(mp);
+
+  /* Wait for a reply... */
+  W(ret);
+  return ret;
+}
 #include <onp/api/onp.api_test.c>
 
 /*

--- a/ET2500/vpp-24.02/src/plugins/onp/api/onp.api
+++ b/ET2500/vpp-24.02/src/plugins/onp/api/onp.api
@@ -87,7 +87,7 @@ define onp_show_counters
  * @param[in] client_index      - opaque cookie to identify the sender
  * @param[in] context           - sender context, to match reply w/ request
  * @param[in] sw_if_index       - index of the interface to set port speed on
- * @param[in] port_speed        - port_speed (kbps)
+ * @param[in] port_speed        - port_speed (Mbps)
  */
 autoreply define onp_set_port_speed
 {

--- a/ET2500/vpp-24.02/src/plugins/onp/api/onp.api
+++ b/ET2500/vpp-24.02/src/plugins/onp/api/onp.api
@@ -18,6 +18,7 @@
 
 option version = "0.1.0";
 import "plugins/onp/api/types.api";
+import "vnet/interface_types.api";
 
 /**
  * @brief Reply to get the ONP plugin version
@@ -78,6 +79,22 @@ define onp_show_counters
 {
   u32 client_index;
   u32 context;
+};
+
+/**
+ * @brief Set the port speed
+ *
+ * @param[in] client_index      - opaque cookie to identify the sender
+ * @param[in] context           - sender context, to match reply w/ request
+ * @param[in] sw_if_index       - index of the interface to set port speed on
+ * @param[in] port_speed        - port_speed (kbps)
+ */
+autoreply define onp_set_port_speed
+{
+  u32 client_index;
+  u32 context;
+  vl_api_interface_index_t sw_if_index;
+  u32 port_speed;
 };
 
 /*

--- a/ET2500/vpp-24.02/src/plugins/onp/cli.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/cli.c
@@ -311,7 +311,7 @@ VLIB_CLI_COMMAND (onp_show_version_command, static) = {
 };
 
 static clib_error_t*
-set_interface_speed(vlib_main_t* vm, unformat_input_t* input, vlib_cli_command_t* cmd) {
+set_onp_interface_speed(vlib_main_t* vm, unformat_input_t* input, vlib_cli_command_t* cmd) {
   clib_error_t* error = 0;
   u32 hw_if_index;
   u32 speed = 0;
@@ -341,10 +341,10 @@ set_interface_speed(vlib_main_t* vm, unformat_input_t* input, vlib_cli_command_t
 }
 
 /* CLI command registration */
-VLIB_CLI_COMMAND(set_interface_speed_command, static) = {
-  .path = "set interface speed",
-  .short_help = "set interface speed <speed> <interface>",
-  .function = set_interface_speed,
+VLIB_CLI_COMMAND(set_onp_interface_speed_command, static) = {
+  .path = "set onp interface speed",
+  .short_help = "set onp interface speed <speed> <interface>",
+  .function = set_onp_interface_speed,
 };
 
 /*

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/inc/pktio.h
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/inc/pktio.h
@@ -325,7 +325,10 @@ i32 cnxk_drv_pktio_xstats_get (vlib_main_t *vm, u16 pktio_idx, u64 *xstats,
 i32 cnxk_drv_pktio_xstats_names_get (vlib_main_t *vm, u16 pktio_idx,
 				     u8 *xstats_names[], u32 count);
 
-i32 cnxk_drv_pktio_link_info_get (vlib_main_t *vm, u16 index,
+i32 cnxk_drv_pktio_link_info_set (vlib_main_t *vm, u16 pktio_idx,
+				  cnxk_pktio_link_info_t *link_info);
+
+i32 cnxk_drv_pktio_link_info_get (vlib_main_t *vm, u16 pktio_idx,
 				  cnxk_pktio_link_info_t *link_info);
 
 u8 *cnxk_drv_pktio_format_rx_trace (u8 *s, va_list *);

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cn10k.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cn10k.c
@@ -541,6 +541,7 @@ cnxk_pktio_ops_t eth_10k_ops = {
   .pktio_multicast_enable = cnxk_pktio_multicast_enable,
   .pktio_multicast_disable  = cnxk_pktio_multicast_disable,
   .pktio_link_info_get = cnxk_pktio_link_info_get,
+  .pktio_link_info_set = cnxk_pktio_link_info_set,
   .pktio_mac_addr_set = cnxk_pktio_mac_addr_set,
   .pktio_mac_addr_get = cnxk_pktio_mac_addr_get,
   .pktio_mac_addr_add = cnxk_pktio_mac_addr_add,

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cn9k.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cn9k.c
@@ -471,6 +471,7 @@ cnxk_pktio_ops_t eth_9k_ops = {
   .pktio_queue_stats_get = cnxk_pktio_queue_stats_get,
   .pktio_promisc_enable = cnxk_pktio_promisc_enable,
   .pktio_link_info_get = cnxk_pktio_link_info_get,
+  .pktio_link_info_set = cnxk_pktio_link_info_set,
   .pktio_mac_addr_set = cnxk_pktio_mac_addr_set,
   .pktio_mac_addr_get = cnxk_pktio_mac_addr_get,
   .pktio_mac_addr_add = cnxk_pktio_mac_addr_add,

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cn9k.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cn9k.c
@@ -471,7 +471,6 @@ cnxk_pktio_ops_t eth_9k_ops = {
   .pktio_queue_stats_get = cnxk_pktio_queue_stats_get,
   .pktio_promisc_enable = cnxk_pktio_promisc_enable,
   .pktio_link_info_get = cnxk_pktio_link_info_get,
-  .pktio_link_info_set = cnxk_pktio_link_info_set,
   .pktio_mac_addr_set = cnxk_pktio_mac_addr_set,
   .pktio_mac_addr_get = cnxk_pktio_mac_addr_get,
   .pktio_mac_addr_add = cnxk_pktio_mac_addr_add,

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cnxk.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cnxk.c
@@ -725,6 +725,28 @@ cnxk_pktio_xstats_get (vlib_main_t *vm, cnxk_pktio_t *dev, u64 *xstats,
 }
 
 i32
+cnxk_pktio_link_info_set(vlib_main_t* vm, cnxk_pktio_t* dev,
+			  cnxk_pktio_link_info_t *link_info)
+{
+  struct roc_nix_link_info nix_info = {};
+  struct roc_nix* nix = &dev->nix;
+  int rv;
+
+  nix_info.status = link_info->is_up;
+  nix_info.full_duplex = link_info->is_full_duplex;
+  nix_info.speed = link_info->speed;
+
+  rv = roc_nix_mac_link_info_set(nix, &nix_info);
+  if (rv) {
+    cnxk_pktio_err(
+      "roc_nix_mac_link_info_set failed with '%s' error on dev %d",
+      roc_error_msg_get(rv), dev->pktio_index, rv);
+    return -1;
+  }
+  return 0;
+}
+
+i32
 cnxk_pktio_link_info_get (vlib_main_t *vm, cnxk_pktio_t *dev,
 			  cnxk_pktio_link_info_t *link_info)
 {
@@ -1119,6 +1141,17 @@ cnxk_drv_pktio_stop (vlib_main_t *vm, u16 pktio_index)
   ASSERT (vm->thread_index == 0);
 
   return ops_map->fops.pktio_stop (vm, &ops_map->pktio);
+}
+
+i32
+cnxk_drv_pktio_link_info_set(vlib_main_t* vm, u16 pktio_index,
+			      cnxk_pktio_link_info_t *link_info)
+{
+  cnxk_pktio_ops_map_t* ops_map = cnxk_pktio_get_pktio_ops(pktio_index);
+
+  ASSERT(vm->thread_index == 0);
+
+  return ops_map->fops.pktio_link_info_set(vm, &ops_map->pktio, link_info);
 }
 
 i32

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cnxk.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_cnxk.c
@@ -736,10 +736,10 @@ cnxk_pktio_link_info_set(vlib_main_t* vm, cnxk_pktio_t* dev,
   nix_info.full_duplex = link_info->is_full_duplex;
   nix_info.speed = link_info->speed;
 
-  rv = roc_nix_mac_link_info_set(nix, &nix_info);
+  rv = roc_nix_mac_link_advertise_set(nix, &nix_info);
   if (rv) {
     cnxk_pktio_err(
-      "roc_nix_mac_link_info_set failed with '%s' error on dev %d",
+      "roc_nix_mac_link_advertise_set failed with '%s' error on dev %d",
       roc_error_msg_get(rv), dev->pktio_index, rv);
     return -1;
   }

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_priv.h
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/modules/pktio/pktio_priv.h
@@ -222,7 +222,11 @@ typedef struct cnxk_pktio_ops
 
   i32 (*pktio_multicast_disable) (vlib_main_t *vm, cnxk_pktio_t *dev);
 
+  i32(*pktio_link_info_set) (vlib_main_t* vm, cnxk_pktio_t* dev,
+    cnxk_pktio_link_info_t* link_info);
+
   i32 (*pktio_mtu_set) (vlib_main_t *vm, cnxk_pktio_t *dev, u32 mtu);
+
   i32 (*pktio_link_info_get) (vlib_main_t *vm, cnxk_pktio_t *dev,
 			      cnxk_pktio_link_info_t *link_info);
 
@@ -396,6 +400,8 @@ i32 cnxk_pktio_stats_clear (vlib_main_t *vm, cnxk_pktio_t *dev);
 i32 cnxk_pktio_queue_stats_clear (vlib_main_t *vm, cnxk_pktio_t *dev, u16 qid,
 				  bool is_rxq);
 u8 cn10k_pktio_is_inl_dev (vlib_main_t *vm, cnxk_pktio_t *dev);
+i32 cnxk_pktio_link_info_set (vlib_main_t *vm, cnxk_pktio_t *dev,
+			      cnxk_pktio_link_info_t *link_info);
 i32 cnxk_pktio_link_info_get (vlib_main_t *vm, cnxk_pktio_t *dev,
 			      cnxk_pktio_link_info_t *link_info);
 u8 *cnxk_pktio_format_rx_trace (u8 *s, va_list *args);

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/roc/base/roc_nix.h
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/roc/base/roc_nix.h
@@ -835,6 +835,8 @@ int __roc_api roc_nix_mac_promisc_mode_enable(struct roc_nix *roc_nix,
 int __roc_api roc_nix_mac_link_state_set(struct roc_nix *roc_nix, uint8_t up);
 int __roc_api roc_nix_mac_link_info_set(struct roc_nix *roc_nix,
 					struct roc_nix_link_info *link_info);
+int __roc_api roc_nix_mac_link_advertise_set(struct roc_nix* roc_nix,
+					struct roc_nix_link_info* link_info);
 int __roc_api roc_nix_mac_link_info_get(struct roc_nix *roc_nix,
 					struct roc_nix_link_info *link_info);
 int __roc_api roc_nix_mac_mtu_set(struct roc_nix *roc_nix, uint16_t mtu);

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/roc/base/roc_nix_mac.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/roc/base/roc_nix_mac.c
@@ -4,6 +4,11 @@
 
 #include "roc_api.h"
 #include "roc_priv.h"
+#define ETH_SPEED_NUM_10G 10000
+#define ETH_SPEED_NUM_1G 1000
+
+#define ETH_SPEED_ADVERTISE_10G 0x10
+#define ETH_SPEED_ADVERTISE_1G 0x2
 
 int
 roc_nix_mac_rxtx_start_stop(struct roc_nix *roc_nix, bool start)
@@ -275,6 +280,36 @@ roc_nix_mac_link_info_set(struct roc_nix *roc_nix,
 	struct dev *dev = &nix->dev;
 	struct mbox *mbox = mbox_get(dev->mbox);
 	struct cgx_set_link_mode_req *req;
+	int rc;
+
+	rc = roc_nix_mac_link_state_set(roc_nix, link_info->status);
+	if (rc)
+		goto exit;
+
+	req = mbox_alloc_msg_cgx_set_link_mode(mbox);
+	if (req == NULL) {
+		rc =  -ENOSPC;
+		goto exit;
+	}
+	req->args.speed = link_info->speed;
+	req->args.duplex = link_info->full_duplex;
+	req->args.an = link_info->autoneg;
+
+	rc = mbox_process(mbox);
+exit:
+	mbox_put(mbox);
+	return rc;
+
+}
+
+int
+roc_nix_mac_link_advertise_set(struct roc_nix *roc_nix,
+			  struct roc_nix_link_info *link_info)
+{
+	struct nix *nix = roc_nix_to_nix_priv(roc_nix);
+	struct dev *dev = &nix->dev;
+	struct mbox *mbox = mbox_get(dev->mbox);
+	struct cgx_set_link_mode_req *req;
 	struct cgx_set_link_mode_rsp *rsp;
 	uint64_t advertising = 0;
 	int rc = -ENOSPC;
@@ -285,10 +320,10 @@ roc_nix_mac_link_info_set(struct roc_nix *roc_nix,
 		goto exit;
 	}
 
-	if (10000 == link_info->speed)
-		advertising = 0x10;
-	else if (1000 == link_info->speed)
-		advertising = 0x2;
+	if (ETH_SPEED_NUM_10G == link_info->speed)
+		advertising = ETH_SPEED_ADVERTISE_10G;
+	else if (ETH_SPEED_NUM_1G == link_info->speed)
+		advertising = ETH_SPEED_ADVERTISE_1G;
 	else {
 		rc = -EINVAL;
 		goto exit;

--- a/ET2500/vpp-24.02/src/plugins/onp/drv/roc/base/roc_nix_mac.c
+++ b/ET2500/vpp-24.02/src/plugins/onp/drv/roc/base/roc_nix_mac.c
@@ -289,6 +289,10 @@ roc_nix_mac_link_info_set(struct roc_nix *roc_nix,
 		advertising = 0x10;
 	else if (1000 == link_info->speed)
 		advertising = 0x2;
+	else {
+		rc = -EINVAL;
+		goto exit;
+	}
 
 	req->args.mode = advertising;
 	rc = mbox_process_msg(mbox, (void**)(&rsp));


### PR DESCRIPTION
**Functionality:**
Users can set port speed for network interfaces via API or CLI.

**Core Changes:**
Added `vl_api_onp_set_port_speed_t_handler` to handle port speed setting requests.
Introduced `set interface speed` CLI command to configure port speed.
Updated driver implementation to support setting port speed via `cnxk_pktio_link_info_set`.

**Limitations:**
Currently supports specific speeds (e.g., 1000Mbps and 10000Mbps); other speeds will return an error.