### PR TITLE
bugfix/ASROUTER-533: check for invalid policer_index in policer_input to prevent coredump

### DIFF
--- a/ET2500/vpp-24.02/src/vnet/policer/policer.c
+++ b/ET2500/vpp-24.02/src/vnet/policer/policer.c
@@ -226,6 +226,9 @@ policer_input (u32 policer_index, u32 sw_if_index, vlib_dir_t dir, bool apply)
 {
   vnet_policer_main_t *pm = &vnet_policer_main;
 
+  if (pool_is_free_index (pm->policers, policer_index))
+    return VNET_API_ERROR_NO_SUCH_ENTRY;
+
   if (apply)
     {
       vec_validate (pm->policer_index_by_sw_if_index[dir], sw_if_index);


### PR DESCRIPTION
same commit in master
https://github.com/FDio/vpp/commit/d1177514c4085f7fcdf09ddfcffa5a5d9a2774a8