### PR TITLE
<Fixbug ASROUTER-637> && <Support ASROUTER-650>

### DIFF
--- a/ET2500/vpp-24.02/src/plugins/linux-cp/CMakeLists.txt
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/CMakeLists.txt
@@ -100,4 +100,5 @@ endif()
 
 if (${ASROUTER_NAME} MATCHES "octeon10")
   add_compile_definitions(ET2500_LCP_DISTINGUISH_LOOPBACK)
+  add_compile_definitions(SUPPORT_LCP_VLAN_TAG_ACT)
 endif()

--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp.api
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp.api
@@ -251,6 +251,41 @@ autoreply define lcp_set_interface_bpdu_drop
   bool is_drop;
 };
 
+enum lcp_itf_host_vlan_tag : u8
+{
+  LCP_API_ITF_HOST_VLAN_TAG_STRIP = 0,
+  LCP_API_ITF_HOST_VLAN_TAG_KEEP = 1,
+  LCP_API_ITF_HOST_VLAN_TAG_ORIGINAL = 2,
+};
+
+/** \brief set interface vlan tag action
+    @param client_index - opaque cookie to identify the sender
+    @param context - sender context, to match reply w/ request
+    @param sw_if_index - index of the interface to set flags on
+    @param vlan_tag - vlan tag action
+*/
+autoreply define lcp_set_interface_vlan_tag
+{
+  u32 client_index;
+  u32 context;
+  vl_api_interface_index_t sw_if_index;
+  vl_api_lcp_itf_host_vlan_tag_t vlan_tag;
+};
+
+/** \brief set interface pvlan
+    @param client_index - opaque cookie to identify the sender
+    @param context - sender context, to match reply w/ request
+    @param sw_if_index - index of the interface to set flags on
+    @param pvlan - pvlan
+*/
+autoreply define lcp_set_interface_pvlan
+{
+  u32 client_index;
+  u32 context;
+  vl_api_interface_index_t sw_if_index;
+  u16 pvlan;
+};
+
 /*
  * Local Variables:
  * eval: (c-set-style "gnu")

--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_api.c
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_api.c
@@ -344,6 +344,52 @@ vl_api_lcp_set_interface_bpdu_drop_t_handler (
   REPLY_MACRO (VL_API_LCP_SET_INTERFACE_BPDU_DROP_REPLY);
 }
 
+static void
+vl_api_lcp_set_interface_vlan_tag_t_handler (
+  vl_api_lcp_set_interface_vlan_tag_t *mp)
+{
+  vl_api_lcp_set_interface_vlan_tag_reply_t *rmp;
+  int rv = 0;
+  u32 sw_if_index = ntohl (mp->sw_if_index);
+  u8 vlan_tag = mp->vlan_tag;
+
+  VALIDATE_SW_IF_INDEX (mp);
+
+#ifdef SUPPORT_LCP_VLAN_TAG_ACT
+  lcp_itf_pair_t *pair = lcp_itf_pair_get (lcp_itf_pair_find_by_phy (sw_if_index));
+
+  if (pair) {
+      pair->lip_host_vlan_tag = vlan_tag;
+  }
+#endif
+
+  BAD_SW_IF_INDEX_LABEL;
+  REPLY_MACRO (VL_API_LCP_SET_INTERFACE_VLAN_TAG_REPLY);
+}
+
+static void
+vl_api_lcp_set_interface_pvlan_t_handler (
+  vl_api_lcp_set_interface_pvlan_t *mp)
+{
+  vl_api_lcp_set_interface_pvlan_reply_t *rmp;
+  int rv = 0;
+  u32 sw_if_index = ntohl (mp->sw_if_index);
+  u16 pvlan = ntohs(mp->pvlan);
+
+  VALIDATE_SW_IF_INDEX (mp);
+
+#ifdef SUPPORT_LCP_VLAN_TAG_ACT
+  lcp_itf_pair_t *pair = lcp_itf_pair_get (lcp_itf_pair_find_by_phy (sw_if_index));
+
+  if (pair) {
+      pair->lip_host_pvlan = pvlan;
+  }
+#endif
+
+  BAD_SW_IF_INDEX_LABEL;
+  REPLY_MACRO (VL_API_LCP_SET_INTERFACE_VLAN_TAG_REPLY);
+}
+
 /*
  * Set up the API message handling tables
  */

--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_cli.c
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_cli.c
@@ -337,6 +337,119 @@ VLIB_CLI_COMMAND (lcp_itf_pair_show_cmd_node, static) = {
   .is_mp_safe = 1,
 };
 
+#ifdef SUPPORT_LCP_VLAN_TAG_ACT
+static clib_error_t *
+lcp_itf_pair_set_vlan_tag_cmd (vlib_main_t *vm, unformat_input_t *input,
+				vlib_cli_command_t *cmd)
+{
+  unformat_input_t _line_input, *line_input = &_line_input;
+  vnet_main_t *vnm = vnet_get_main ();
+  u32 sw_if_index = ~0;
+  clib_error_t *error = NULL;
+  lcp_itf_pair_t *pair = NULL;
+  lip_host_vlan_tag_e type = LCP_ITF_HOST_VLAN_TAG_ORIGINAL;
+
+  if (unformat_user (input, unformat_line_input, line_input))
+    {
+      while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
+	{
+	  if (unformat (line_input, "phy %U", unformat_vnet_sw_interface, vnm,
+			     &sw_if_index))
+	    ;
+	  else if (unformat (line_input, "vlan_tag strip"))
+          type = LCP_ITF_HOST_VLAN_TAG_STRIP;
+	  else if (unformat (line_input, "vlan_tag keep"))
+          type = LCP_ITF_HOST_VLAN_TAG_KEEP;
+	  else if (unformat (line_input, "vlan_tag orig"))
+          type = LCP_ITF_HOST_VLAN_TAG_ORIGINAL;
+	  else
+	    {
+	      error = clib_error_return (0, "unknown input `%U'",
+					 format_unformat_error, line_input);
+	      break;
+	    }
+	}
+      unformat_free (line_input);
+    }
+
+  if (error) return error;
+  else if (sw_if_index == ~0)
+    error = clib_error_return (0, "interface name or sw_if_index required");
+
+  pair = lcp_itf_pair_get (lcp_itf_pair_find_by_phy (sw_if_index));
+
+  if (pair)
+  {
+      pair->lip_host_vlan_tag = type;
+  }
+  else
+  {
+    error = clib_error_return (0, "interface name or sw_if_index not has lcp_itf_pair");
+  }
+  return error;
+}
+
+
+VLIB_CLI_COMMAND (lcp_itf_pair_set_vlan_tag_cmd_node, static) = {
+  .path = "lcp set vlan-tag",
+  .function = lcp_itf_pair_set_vlan_tag_cmd,
+  .short_help = "lcp set vlan-tag phy <interface> vlan_tag (strip|keep|orig)",
+};
+
+static clib_error_t *
+lcp_itf_pair_set_pvlan_cmd (vlib_main_t *vm, unformat_input_t *input,
+				vlib_cli_command_t *cmd)
+{
+  unformat_input_t _line_input, *line_input = &_line_input;
+  vnet_main_t *vnm = vnet_get_main ();
+  u32 sw_if_index = ~0;
+  clib_error_t *error = NULL;
+  lcp_itf_pair_t *pair = NULL;
+  u16 pvlan = 0xffff;
+
+  if (unformat_user (input, unformat_line_input, line_input))
+    {
+      while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
+	{
+	  if (unformat (line_input, "phy %U", unformat_vnet_sw_interface, vnm,
+			     &sw_if_index))
+	    ;
+	  else if (unformat (line_input, "pvlan %u", &pvlan))
+	    ;
+	  else
+	    {
+	      error = clib_error_return (0, "unknown input `%U'",
+					 format_unformat_error, line_input);
+	      break;
+	    }
+	}
+      unformat_free (line_input);
+    }
+
+  if (error) return error;
+  else if (sw_if_index == ~0)
+    error = clib_error_return (0, "interface name or sw_if_index required");
+
+  pair = lcp_itf_pair_get (lcp_itf_pair_find_by_phy (sw_if_index));
+
+  if (pair)
+  {
+      pair->lip_host_pvlan = pvlan;
+  }
+  else
+  {
+    error = clib_error_return (0, "interface name or sw_if_index not has lcp_itf_pair");
+  }
+  return error;
+}
+
+VLIB_CLI_COMMAND (lcp_itf_pair_set_pvlan_cmd_node, static) = {
+  .path = "lcp set pvlan",
+  .function = lcp_itf_pair_set_pvlan_cmd,
+  .short_help = "lcp set pvlan phy <interface> pvlan <pvlan>",
+};
+#endif
+
 clib_error_t *
 lcp_cli_init (vlib_main_t *vm)
 {

--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_interface.c
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_interface.c
@@ -105,6 +105,21 @@ format_lcp_itf_pair (u8 *s, va_list *args)
   if (lip->lip_namespace)
     s = format (s, " netns %s", lip->lip_namespace);
 
+#ifdef SUPPORT_LCP_VLAN_TAG_ACT
+  switch(lip->lip_host_vlan_tag)
+  {
+  case LCP_ITF_HOST_VLAN_TAG_STRIP:
+      s = format (s, " vlan-tag-type strip(pvlan %d)", lip->lip_host_pvlan);
+      break;
+  case LCP_ITF_HOST_VLAN_TAG_KEEP:
+      s = format (s, " vlan-tag-type keep(pvlan %d)", lip->lip_host_pvlan);
+      break;
+  case LCP_ITF_HOST_VLAN_TAG_ORIGINAL:
+      s = format (s, " vlan-tag-type original(pvlan %d)", lip->lip_host_pvlan);
+      break;
+  }
+#endif
+
   return s;
 }
 
@@ -380,6 +395,12 @@ lcp_itf_pair_add (u32 host_sw_if_index, u32 phy_sw_if_index, u8 *host_name,
 
   /* set timestamp when pair entered service */
   lip->lip_create_ts = vlib_time_now (vlib_get_main ());
+
+#ifdef SUPPORT_LCP_VLAN_TAG_ACT
+  /* set default vlan tag action and pvlan */
+  lip->lip_host_vlan_tag = LCP_ITF_HOST_VLAN_TAG_ORIGINAL;
+  lip->lip_host_pvlan = 0xffff;
+#endif
 
   return 0;
 }

--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_interface.h
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_interface.h
@@ -59,6 +59,35 @@ typedef struct lcp_itf_phy_adj
   adj_index_t adj_index[N_AF];
 } lcp_itf_phy_adj_t;
 
+#ifdef SUPPORT_LCP_VLAN_TAG_ACT
+typedef enum
+{
+    /**
+     * @brief Strip vlan tag
+     * Strip vlan tag from the incoming packet
+     * when delivering the packet to host interface.
+     */
+    LCP_ITF_HOST_VLAN_TAG_STRIP,
+
+    /**
+     * @brief Keep vlan tag.
+     * When incoming packet is untagged, add PVID tag to the packet when delivering
+     * the packet to host interface.
+     */
+    LCP_ITF_HOST_VLAN_TAG_KEEP,
+
+    /**
+     * @brief Keep the packet same as the incoming packet
+     *
+     * The packet delivered to host interface is the same as the original packet.
+     * When the host interface is PORT and LAG, the packet delivered to host interface is the
+     * same as the original packet seen by the PORT and LAG.
+     * When the host interface is VLAN, the packet delivered to host interface will not have tag.
+     */
+    LCP_ITF_HOST_VLAN_TAG_ORIGINAL,
+} lip_host_vlan_tag_e;
+#endif
+
 /**
  * A pair of interfaces
  */
@@ -74,6 +103,11 @@ typedef struct lcp_itf_pair_t_
   lip_flag_t lip_flags;		  /* Flags */
   u8 lip_rewrite_len;		  /* The length of an L2 MAC rewrite */
   f64 lip_create_ts;		  /* Timestamp of creation */
+
+#ifdef SUPPORT_LCP_VLAN_TAG_ACT
+  lip_host_vlan_tag_e lip_host_vlan_tag; /* type of host interface vlan action */
+  u16 lip_host_pvlan;         /* pvlan */
+#endif
 } lcp_itf_pair_t;
 extern lcp_itf_pair_t *lcp_itf_pair_pool;
 


### PR DESCRIPTION
Support LCP vlan-tag-act:
1. vlan-tag-act support <strip,keep,orig>
2. only in punt and arp punt need vlan-tag-act
3. For transmitted through  ip46-punt, no processing will be performed
    Whether for bvi, sub interface, or phy port, if lcp punt received packet from ip46-punt. This means that it is an L3 packet, and only the original needs to be punt.
4. For packet similar to lcp_bpdu/lcp_lldp that we have added ourselves, there is no need to perform vlan tagging, so next node need set interface-output. For packet similar to lcp_ndp/lcp_dhcp that we hace added ourselves, there is need to perform vlan tagging in L2, so next node need set lcp-punt.
5. when vlan-tag-act is keep and the packet not have vlan  will check lcp_itf_pair pvlan, if pvlan range in (0,4095) , add vlan-tag. if pvlan (> 4095),  is an invalid pvlan and does not add vlan-tag.
