### PR TITLE
Fixbug/asrouter 1357

### DIFF
--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_ndp.c
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_ndp.c
@@ -135,54 +135,58 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
           icmp0 = ip6_ext_header_find(vm, b0, ip60, IP_PROTOCOL_ICMP6, NULL);
           if(icmp0)
           {
-              if(PREDICT_FALSE(
-                 ICMP6_neighbor_solicitation == icmp0->type ||
-                 ICMP6_neighbor_advertisement == icmp0->type ||
-                 ICMP6_router_solicitation == icmp0->type ||
-                 ICMP6_router_advertisement == icmp0->type ||
-                 ICMP6_redirect == icmp0->type
-                 ))
-              {
-		  len0 = ((u8 *) vlib_buffer_get_current (b0) - (u8 *) ethernet_buffer_get_header (b0));
-		  vlib_buffer_advance (b0, -len0);
-		  c0 = vlib_buffer_copy (vm, b0);
-		  vlib_buffer_advance (b0, len0);
-		  if (c0)
-		  {
-		      copies[n_copies++] = vlib_get_buffer_index (vm, c0);
-          /*
-          * Mark only the original NS. The copy was made before this
-          * assignment, so the copy does not inherit the marker.
-          */
-          if (icmp0->type == ICMP6_neighbor_solicitation &&
-	        lcp_ndp_host_pair_exists (b0))
-          vnet_buffer2 (b0)->lcp_host_copy_done = 1;
-		  }
+            if(PREDICT_FALSE(
+              ICMP6_neighbor_solicitation == icmp0->type ||
+              ICMP6_neighbor_advertisement == icmp0->type ||
+              ICMP6_router_solicitation == icmp0->type ||
+              ICMP6_router_advertisement == icmp0->type ||
+              ICMP6_redirect == icmp0->type
+            ))
+            {
+              if (lcp_ndp_host_pair_exists (b0))
+	            {
+		            len0 = ((u8 *) vlib_buffer_get_current (b0) - (u8 *) ethernet_buffer_get_header (b0));
+		            vlib_buffer_advance (b0, -len0);
+		            c0 = vlib_buffer_copy (vm, b0);
+		            vlib_buffer_advance (b0, len0);
+		            if (c0)
+		            {
+		              copies[n_copies++] = vlib_get_buffer_index (vm, c0);
+                  /*
+                  * Mark only the original NS. The copy was made before this
+                  * assignment, so the copy does not inherit the marker.
+                  */
+                  if (icmp0->type == ICMP6_neighbor_solicitation)
+                    vnet_buffer2 (b0)->lcp_host_copy_done = 1;
+		            }
               }
+            }
           }
 
           icmp1 = ip6_ext_header_find(vm, b1, ip61, IP_PROTOCOL_ICMP6, NULL);
           if (icmp1)
           {
-              if(PREDICT_FALSE(
-                 ICMP6_neighbor_solicitation == icmp1->type ||
-                 ICMP6_neighbor_advertisement == icmp1->type ||
-                 ICMP6_router_solicitation == icmp1->type ||
-                 ICMP6_router_advertisement == icmp1->type ||
-                 ICMP6_redirect == icmp1->type
-                ))
-              {
-		  len1 = ((u8 *) vlib_buffer_get_current (b1) - (u8 *) ethernet_buffer_get_header (b1));
-		  vlib_buffer_advance (b1, -len1);
-		  c1 = vlib_buffer_copy (vm, b1);
-		  vlib_buffer_advance (b1, len1);
-		  if (c1)
-		  {
-		      copies[n_copies++] = vlib_get_buffer_index (vm, c1);
-          if (icmp1->type == ICMP6_neighbor_solicitation && lcp_ndp_host_pair_exists (b1))
-          vnet_buffer2 (b1)->lcp_host_copy_done = 1;
-		  }
+            if(PREDICT_FALSE(
+              ICMP6_neighbor_solicitation == icmp1->type ||
+              ICMP6_neighbor_advertisement == icmp1->type ||
+              ICMP6_router_solicitation == icmp1->type ||
+              ICMP6_router_advertisement == icmp1->type ||
+              ICMP6_redirect == icmp1->type
+            ))
+            {
+              if (lcp_ndp_host_pair_exists (b1)){
+		            len1 = ((u8 *) vlib_buffer_get_current (b1) - (u8 *) ethernet_buffer_get_header (b1));
+		            vlib_buffer_advance (b1, -len1);
+		            c1 = vlib_buffer_copy (vm, b1);
+		            vlib_buffer_advance (b1, len1);
+		            if (c1)
+		            {
+		              copies[n_copies++] = vlib_get_buffer_index (vm, c1);
+                  if (icmp1->type == ICMP6_neighbor_solicitation)
+                    vnet_buffer2 (b1)->lcp_host_copy_done = 1;
+		            }
               }
+            }
           }
 
       if (b0->flags & VLIB_BUFFER_IS_TRACED)
@@ -239,25 +243,28 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
           icmp = ip6_ext_header_find(vm, b0, ip6, IP_PROTOCOL_ICMP6, NULL);
           if(icmp)
           {
-              if(PREDICT_FALSE(
-                 ICMP6_neighbor_solicitation == icmp->type ||
-                 ICMP6_neighbor_advertisement == icmp->type ||
-                 ICMP6_router_solicitation == icmp->type ||
-                 ICMP6_router_advertisement == icmp->type ||
-                 ICMP6_redirect == icmp->type
-                 ))
+            if(PREDICT_FALSE(
+              ICMP6_neighbor_solicitation == icmp->type ||
+              ICMP6_neighbor_advertisement == icmp->type ||
+              ICMP6_router_solicitation == icmp->type ||
+              ICMP6_router_advertisement == icmp->type ||
+              ICMP6_redirect == icmp->type
+            ))
+            {
+              if (lcp_ndp_host_pair_exists (b0))
               {
-		  len = ((u8 *) vlib_buffer_get_current (b0) - (u8 *) ethernet_buffer_get_header (b0));
-		  vlib_buffer_advance (b0, -len);
-		  c = vlib_buffer_copy (vm, b0);
-		  vlib_buffer_advance (b0, len);
-		  if (c)
-		  {
-		      copies[n_copies++] = vlib_get_buffer_index (vm, c);
-          if (icmp->type == ICMP6_neighbor_solicitation && lcp_ndp_host_pair_exists (b0))
-          vnet_buffer2 (b0)->lcp_host_copy_done = 1;
-		  }
+		            len = ((u8 *) vlib_buffer_get_current (b0) - (u8 *) ethernet_buffer_get_header (b0));
+		            vlib_buffer_advance (b0, -len);
+		            c = vlib_buffer_copy (vm, b0);
+		            vlib_buffer_advance (b0, len);
+		            if (c)
+		            {
+		              copies[n_copies++] = vlib_get_buffer_index (vm, c);
+                  if (icmp->type == ICMP6_neighbor_solicitation)
+                  vnet_buffer2 (b0)->lcp_host_copy_done = 1;
+		            }
               }
+            }
           }
 
 

--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_ndp.c
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_ndp.c
@@ -17,6 +17,7 @@
 
 #include <vnet/feature/feature.h>
 #include <vppinfra/error.h>
+#include <plugins/linux-cp/lcp_interface.h>
 #include <linux-cp/lcp.api_enum.h>
 
 #define foreach_lcp_ndp                                                       \
@@ -48,6 +49,39 @@ format_lcp_ndp_trace (u8 * s, va_list * va)
 	      format_ip6_header, t->packet_data, sizeof (t->packet_data));
 
   return s;
+}
+
+static_always_inline int
+lcp_ndp_host_pair_exists (vlib_buffer_t *b)
+{
+  index_t lipi;
+  u32 phy_sw_if_index;
+
+  phy_sw_if_index = vnet_buffer (b)->sw_if_index[VLIB_RX];
+  lipi = lcp_itf_pair_find_by_phy (phy_sw_if_index);
+
+  /*
+   * After an L2-to-BVI transition, the RX sw_if_index can refer to
+   * the BVI. Recover the original physical RX interface in the same
+   * way as linux-cp-punt.
+   */
+  if (lipi == INDEX_INVALID &&
+      (b->flags & VLIB_BUFFER_NOT_PHY_INTF) &&
+      vnet_buffer2 (b)->l2_rx_sw_if_index != ~0)
+    {
+      vnet_sw_interface_t *si;
+
+      phy_sw_if_index = vnet_buffer2 (b)->l2_rx_sw_if_index;
+      si = vnet_get_sw_interface_or_null (vnet_get_main (),
+					   phy_sw_if_index);
+
+      if (si != NULL && si->type == VNET_SW_INTERFACE_TYPE_SUB)
+	phy_sw_if_index = si->sup_sw_if_index;
+
+      lipi = lcp_itf_pair_find_by_phy (phy_sw_if_index);
+    }
+
+  return (lipi != INDEX_INVALID);
 }
 
 VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
@@ -116,6 +150,14 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
 		  if (c0)
 		  {
 		      copies[n_copies++] = vlib_get_buffer_index (vm, c0);
+          /*
+          * Mark only the original NS. The copy was made before this
+          * assignment, so the copy does not inherit the marker.
+          */
+          if (icmp0->type == ICMP6_neighbor_solicitation &&
+	        lcp_ndp_host_pair_exists (b0))
+          vnet_buffer2 (b0)->lcp_host_copy_flags |=
+          VNET_BUFFER_LCP_HOST_COPY_NDP;
 		  }
               }
           }
@@ -138,6 +180,9 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
 		  if (c1)
 		  {
 		      copies[n_copies++] = vlib_get_buffer_index (vm, c1);
+          if (icmp1->type == ICMP6_neighbor_solicitation && lcp_ndp_host_pair_exists (b1))
+          vnet_buffer2 (b1)->lcp_host_copy_flags |=
+        VNET_BUFFER_LCP_HOST_COPY_NDP;
 		  }
               }
           }
@@ -148,7 +193,7 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
               vlib_add_trace (vm, node, b0, sizeof (*t0));
 
           t0->sw_if_index = sw_if_index0;
-	  clib_memcpy_fast (t0, b0->data + b0->current_data, LCP_NDP_TRACE_DATA_SIZE);
+	  clib_memcpy_fast (t0->packet_data, b0->data + b0->current_data, LCP_NDP_TRACE_DATA_SIZE);
       }
 
       if (b1->flags & VLIB_BUFFER_IS_TRACED)
@@ -157,7 +202,7 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
               vlib_add_trace (vm, node, b1, sizeof (*t1));
 
           t1->sw_if_index = sw_if_index1;
-	  clib_memcpy_fast (t1, b1->data + b1->current_data, LCP_NDP_TRACE_DATA_SIZE);
+	  clib_memcpy_fast (t1->packet_data, b1->data + b1->current_data, LCP_NDP_TRACE_DATA_SIZE);
       }
 
 	  from += 2;
@@ -211,6 +256,9 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
 		  if (c)
 		  {
 		      copies[n_copies++] = vlib_get_buffer_index (vm, c);
+          if (icmp->type == ICMP6_neighbor_solicitation && lcp_ndp_host_pair_exists (b0))
+          vnet_buffer2 (b0)->lcp_host_copy_flags |=
+        VNET_BUFFER_LCP_HOST_COPY_NDP;
 		  }
               }
           }
@@ -222,7 +270,7 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
               vlib_add_trace (vm, node, b0, sizeof (*t));
 
           t->sw_if_index = sw_if_index0;
-	  clib_memcpy_fast (t, b0->data + b0->current_data, LCP_NDP_TRACE_DATA_SIZE);
+	  clib_memcpy_fast (t->packet_data, b0->data + b0->current_data, LCP_NDP_TRACE_DATA_SIZE);
       }
 
 	  from += 1;

--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_ndp.c
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_ndp.c
@@ -156,8 +156,7 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
           */
           if (icmp0->type == ICMP6_neighbor_solicitation &&
 	        lcp_ndp_host_pair_exists (b0))
-          vnet_buffer2 (b0)->lcp_host_copy_flags |=
-          VNET_BUFFER_LCP_HOST_COPY_NDP;
+          vnet_buffer2 (b0)->lcp_host_copy_done = 1;
 		  }
               }
           }
@@ -181,8 +180,7 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
 		  {
 		      copies[n_copies++] = vlib_get_buffer_index (vm, c1);
           if (icmp1->type == ICMP6_neighbor_solicitation && lcp_ndp_host_pair_exists (b1))
-          vnet_buffer2 (b1)->lcp_host_copy_flags |=
-        VNET_BUFFER_LCP_HOST_COPY_NDP;
+          vnet_buffer2 (b1)->lcp_host_copy_done = 1;
 		  }
               }
           }
@@ -257,8 +255,7 @@ VLIB_NODE_FN (lcp_ndp_phy_node) (vlib_main_t * vm,
 		  {
 		      copies[n_copies++] = vlib_get_buffer_index (vm, c);
           if (icmp->type == ICMP6_neighbor_solicitation && lcp_ndp_host_pair_exists (b0))
-          vnet_buffer2 (b0)->lcp_host_copy_flags |=
-        VNET_BUFFER_LCP_HOST_COPY_NDP;
+          vnet_buffer2 (b0)->lcp_host_copy_done = 1;
 		  }
               }
           }

--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_node.c
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_node.c
@@ -911,7 +911,7 @@ VLIB_NODE_FN (lcp_arp_phy_node)
 		       * arp-reply will use this to decide whether VPP can
 		       * safely suppress its own Reply.
 		       */
-			vnet_buffer2 (b0)->lcp_host_copy_flags |= VNET_BUFFER_LCP_HOST_COPY_ARP;
+			vnet_buffer2 (b0)->lcp_host_copy_done = 1;
 #ifdef SUPPORT_LCP_VLAN_TAG_ACT
 		      lip_punt_vlan_tag_proc(lip0, c0);
 #endif
@@ -961,7 +961,7 @@ VLIB_NODE_FN (lcp_arp_phy_node)
 		      reply_copies[n_copies++] =
 			vlib_get_buffer_index (vm, c1);
 		      /* Mark only the original buffer.*/
-			vnet_buffer2 (b1)->lcp_host_copy_flags |= VNET_BUFFER_LCP_HOST_COPY_ARP;
+			vnet_buffer2 (b1)->lcp_host_copy_done = 1;
 #ifdef SUPPORT_LCP_VLAN_TAG_ACT
 		      lip_punt_vlan_tag_proc(lip1, c1);
 #endif
@@ -1059,7 +1059,7 @@ VLIB_NODE_FN (lcp_arp_phy_node)
 		      /*
 		       * Mark only the original buffer.
 		       */
-			vnet_buffer2 (b0)->lcp_host_copy_flags |= VNET_BUFFER_LCP_HOST_COPY_ARP;
+			vnet_buffer2 (b0)->lcp_host_copy_done = 1;
 #ifdef SUPPORT_LCP_VLAN_TAG_ACT
 		      lip_punt_vlan_tag_proc(lip0, c0);
 #endif

--- a/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_node.c
+++ b/ET2500/vpp-24.02/src/plugins/linux-cp/lcp_node.c
@@ -911,7 +911,7 @@ VLIB_NODE_FN (lcp_arp_phy_node)
 		       * arp-reply will use this to decide whether VPP can
 		       * safely suppress its own Reply.
 		       */
-		      vnet_buffer2 (b0)->lcp_arp_host_copy_done = 1;
+			vnet_buffer2 (b0)->lcp_host_copy_flags |= VNET_BUFFER_LCP_HOST_COPY_ARP;
 #ifdef SUPPORT_LCP_VLAN_TAG_ACT
 		      lip_punt_vlan_tag_proc(lip0, c0);
 #endif
@@ -961,7 +961,7 @@ VLIB_NODE_FN (lcp_arp_phy_node)
 		      reply_copies[n_copies++] =
 			vlib_get_buffer_index (vm, c1);
 		      /* Mark only the original buffer.*/
-		      vnet_buffer2 (b1)->lcp_arp_host_copy_done = 1;
+			vnet_buffer2 (b1)->lcp_host_copy_flags |= VNET_BUFFER_LCP_HOST_COPY_ARP;
 #ifdef SUPPORT_LCP_VLAN_TAG_ACT
 		      lip_punt_vlan_tag_proc(lip1, c1);
 #endif
@@ -1059,7 +1059,7 @@ VLIB_NODE_FN (lcp_arp_phy_node)
 		      /*
 		       * Mark only the original buffer.
 		       */
-		      vnet_buffer2 (b0)->lcp_arp_host_copy_done = 1;
+			vnet_buffer2 (b0)->lcp_host_copy_flags |= VNET_BUFFER_LCP_HOST_COPY_ARP;
 #ifdef SUPPORT_LCP_VLAN_TAG_ACT
 		      lip_punt_vlan_tag_proc(lip0, c0);
 #endif

--- a/ET2500/vpp-24.02/src/vnet/arp/arp.c
+++ b/ET2500/vpp-24.02/src/vnet/arp/arp.c
@@ -247,7 +247,7 @@ arp_input (vlib_main_t * vm, vlib_node_runtime_t * node, vlib_frame_t * frame)
 	  n_left_to_next -= 1;
 
 	  p0 = vlib_get_buffer (vm, pi0);
-	  vnet_buffer2 (p0)->lcp_arp_host_copy_done = 0;
+	  vnet_buffer2 (p0)->lcp_host_copy_flags = 0;
 	  arp0 = vlib_buffer_get_current (p0);
 
 	  error0 = ARP_ERROR_REPLIES_SENT;
@@ -671,7 +671,8 @@ if (arp0->opcode ==
       clib_host_to_net_u16 (ETHERNET_ARP_OPCODE_request) &&
     dst_is_local0 &&
     !is_unnumbered0 &&
-    vnet_buffer2 (p0)->lcp_arp_host_copy_done)
+    (vnet_buffer2 (p0)->lcp_host_copy_flags &
+    VNET_BUFFER_LCP_HOST_COPY_ARP))
   {
     error0 = ARP_ERROR_REPLY_SUPPRESSED_LINUX_OWNER;
     goto drop;

--- a/ET2500/vpp-24.02/src/vnet/arp/arp.c
+++ b/ET2500/vpp-24.02/src/vnet/arp/arp.c
@@ -247,7 +247,7 @@ arp_input (vlib_main_t * vm, vlib_node_runtime_t * node, vlib_frame_t * frame)
 	  n_left_to_next -= 1;
 
 	  p0 = vlib_get_buffer (vm, pi0);
-	  vnet_buffer2 (p0)->lcp_host_copy_flags = 0;
+	  vnet_buffer2 (p0)->lcp_host_copy_done = 0;
 	  arp0 = vlib_buffer_get_current (p0);
 
 	  error0 = ARP_ERROR_REPLIES_SENT;
@@ -671,8 +671,7 @@ if (arp0->opcode ==
       clib_host_to_net_u16 (ETHERNET_ARP_OPCODE_request) &&
     dst_is_local0 &&
     !is_unnumbered0 &&
-    (vnet_buffer2 (p0)->lcp_host_copy_flags &
-    VNET_BUFFER_LCP_HOST_COPY_ARP))
+    vnet_buffer2 (p0)->lcp_host_copy_done)
   {
     error0 = ARP_ERROR_REPLY_SUPPRESSED_LINUX_OWNER;
     goto drop;

--- a/ET2500/vpp-24.02/src/vnet/buffer.h
+++ b/ET2500/vpp-24.02/src/vnet/buffer.h
@@ -457,6 +457,13 @@ STATIC_ASSERT (sizeof (vnet_buffer_opaque_t) <=
 
 #define vnet_buffer(b) ((vnet_buffer_opaque_t *) (b)->opaque)
 
+
+/*
+ * Per-packet flags recording which LCP protocol successfully created
+ * a copy for the Linux host.
+ */
+#define VNET_BUFFER_LCP_HOST_COPY_ARP (1 << 0)
+#define VNET_BUFFER_LCP_HOST_COPY_NDP (1 << 1)
 /* Full cache line (64 bytes) of additional space */
 typedef struct
 {
@@ -517,7 +524,7 @@ typedef struct
   /*
   * Set by linux-cp-arp-phy when an ARP packet has been
   * successfully copied and queued for the Linux host interface.*/
-  u8 lcp_arp_host_copy_done;
+  u8 lcp_host_copy_flags;
   };
 
   u32 unused[8];

--- a/ET2500/vpp-24.02/src/vnet/buffer.h
+++ b/ET2500/vpp-24.02/src/vnet/buffer.h
@@ -458,12 +458,7 @@ STATIC_ASSERT (sizeof (vnet_buffer_opaque_t) <=
 #define vnet_buffer(b) ((vnet_buffer_opaque_t *) (b)->opaque)
 
 
-/*
- * Per-packet flags recording which LCP protocol successfully created
- * a copy for the Linux host.
- */
-#define VNET_BUFFER_LCP_HOST_COPY_ARP (1 << 0)
-#define VNET_BUFFER_LCP_HOST_COPY_NDP (1 << 1)
+
 /* Full cache line (64 bytes) of additional space */
 typedef struct
 {
@@ -522,9 +517,9 @@ typedef struct
   u32 actual_tx_sw_if_index;
   u8 tc_index_dpo; /* store the traffic class dpo */
   /*
-  * Set by linux-cp-arp-phy when an ARP packet has been
+  * Set by linux-cp-arp-phy when an ARP packet or a NDP packet has been
   * successfully copied and queued for the Linux host interface.*/
-  u8 lcp_host_copy_flags;
+  u8 lcp_host_copy_done : 1;
   };
 
   u32 unused[8];

--- a/ET2500/vpp-24.02/src/vnet/ip/ip.api
+++ b/ET2500/vpp-24.02/src/vnet/ip/ip.api
@@ -1721,12 +1721,6 @@ counters icmp6 {
     units "packets";
     description "neighbor advertisements sent";
   };
-  neighbor_advertisement_suppressed_linux_owner {
-    severity info;
-    type counter64;
-    units "packets";
-    description "neighbor advertisement suppressed because Linux is the reply owner";
-  };
   neighbor_advertisements_rx {
     severity info;
     type counter64;
@@ -1810,6 +1804,12 @@ counters icmp6 {
     type counter64;
     units "packets";
     description "buffer allocation failure";
+  };
+  neighbor_advertisement_suppressed_linux_owner {
+    severity info;
+    type counter64;
+    units "packets";
+    description "neighbor advertisement suppressed because Linux is the reply owner";
   };
 };
 

--- a/ET2500/vpp-24.02/src/vnet/ip/ip.api
+++ b/ET2500/vpp-24.02/src/vnet/ip/ip.api
@@ -1721,6 +1721,12 @@ counters icmp6 {
     units "packets";
     description "neighbor advertisements sent";
   };
+  neighbor_advertisement_suppressed_linux_owner {
+    severity info;
+    type counter64;
+    units "packets";
+    description "neighbor advertisement suppressed because Linux is the reply owner";
+  };
   neighbor_advertisements_rx {
     severity info;
     type counter64;

--- a/ET2500/vpp-24.02/src/vnet/ip/ip6_input.c
+++ b/ET2500/vpp-24.02/src/vnet/ip/ip6_input.c
@@ -139,8 +139,8 @@ VLIB_NODE_FN (ip6_input_node) (vlib_main_t * vm, vlib_node_runtime_t * node,
     * opaque2 is not guaranteed to be zero when a buffer is reused.
     * Clear LCP host-copy state before starting the IPv6 feature arc.
     */
-    vnet_buffer2 (p0)->lcp_host_copy_flags = 0;
-    vnet_buffer2 (p1)->lcp_host_copy_flags = 0;
+    vnet_buffer2 (p0)->lcp_host_copy_done = 0;
+    vnet_buffer2 (p1)->lcp_host_copy_done = 0;
 
 	  ip0 = vlib_buffer_get_current (p0);
 	  ip1 = vlib_buffer_get_current (p1);
@@ -226,7 +226,7 @@ VLIB_NODE_FN (ip6_input_node) (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  p0 = vlib_get_buffer (vm, pi0);
-    vnet_buffer2 (p0)->lcp_host_copy_flags = 0;
+    vnet_buffer2 (p0)->lcp_host_copy_done = 0;
 	  ip0 = vlib_buffer_get_current (p0);
 
 	  sw_if_index0 = vnet_buffer (p0)->sw_if_index[VLIB_RX];

--- a/ET2500/vpp-24.02/src/vnet/ip/ip6_input.c
+++ b/ET2500/vpp-24.02/src/vnet/ip/ip6_input.c
@@ -135,6 +135,13 @@ VLIB_NODE_FN (ip6_input_node) (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  p0 = vlib_get_buffer (vm, pi0);
 	  p1 = vlib_get_buffer (vm, pi1);
 
+    /*
+    * opaque2 is not guaranteed to be zero when a buffer is reused.
+    * Clear LCP host-copy state before starting the IPv6 feature arc.
+    */
+    vnet_buffer2 (p0)->lcp_host_copy_flags = 0;
+    vnet_buffer2 (p1)->lcp_host_copy_flags = 0;
+
 	  ip0 = vlib_buffer_get_current (p0);
 	  ip1 = vlib_buffer_get_current (p1);
 
@@ -219,6 +226,7 @@ VLIB_NODE_FN (ip6_input_node) (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  p0 = vlib_get_buffer (vm, pi0);
+    vnet_buffer2 (p0)->lcp_host_copy_flags = 0;
 	  ip0 = vlib_buffer_get_current (p0);
 
 	  sw_if_index0 = vnet_buffer (p0)->sw_if_index[VLIB_RX];

--- a/ET2500/vpp-24.02/src/vnet/ip6-nd/ip6_nd.c
+++ b/ET2500/vpp-24.02/src/vnet/ip6-nd/ip6_nd.c
@@ -90,6 +90,7 @@ icmp6_neighbor_solicitation_or_advertisement (vlib_main_t * vm,
 	  icmp6_neighbor_discovery_ethernet_link_layer_address_option_t *o0;
 	  u32 bi0, options_len0, sw_if_index0, next0, error0;
 	  u32 ip6_sadd_link_local, ip6_sadd_unspecified;
+	  u8 target_is_interface_local0;
 	  ip_neighbor_counter_type_t c_type;
 	  int is_rewrite0;
 	  u32 ni0;
@@ -109,6 +110,7 @@ icmp6_neighbor_solicitation_or_advertisement (vlib_main_t * vm,
 
 	  error0 = ICMP6_ERROR_NONE;
 	  sw_if_index0 = vnet_buffer (p0)->sw_if_index[VLIB_RX];
+	  target_is_interface_local0 = 0;
 	  ip6_sadd_link_local =
 	    ip6_address_is_link_local_unicast (&ip0->src_address);
 	  ip6_sadd_unspecified =
@@ -206,6 +208,15 @@ icmp6_neighbor_solicitation_or_advertisement (vlib_main_t * vm,
 			{
 			  /* It's an address that belongs to one of our interfaces
 			   * that's good. */
+			   /*
+			   * Suppress VPP's NA only when the local address belongs to
+			   * the interface on which this NS was received. Linux NDP
+			   * ownership is interface-specific.
+			   */
+			   target_is_interface_local0 =(sw_if_index0 ==
+				fib_entry_get_resolving_interface_for_source (
+					fei, FIB_SOURCE_INTERFACE));
+
 			}
 		      else if (FIB_ENTRY_FLAG_LOCAL &
 			       fib_entry_get_flags_for_source (
@@ -232,6 +243,14 @@ icmp6_neighbor_solicitation_or_advertisement (vlib_main_t * vm,
 
 	  if (is_solicitation)
 	    {
+			if(error0 == ICMP6_ERROR_NONE &&
+				target_is_interface_local0 &&
+				(vnet_buffer2(p0)->lcp_host_copy_flags &
+				VNET_BUFFER_LCP_HOST_COPY_NDP)
+			){
+				error0 =
+					ICMP6_ERROR_NEIGHBOR_ADVERTISEMENT_SUPPRESSED_LINUX_OWNER;
+			}
 	      next0 = (error0 != ICMP6_ERROR_NONE ?
 			       ICMP6_NEIGHBOR_SOLICITATION_NEXT_DROP :
 			       ICMP6_NEIGHBOR_SOLICITATION_NEXT_REPLY);

--- a/ET2500/vpp-24.02/src/vnet/ip6-nd/ip6_nd.c
+++ b/ET2500/vpp-24.02/src/vnet/ip6-nd/ip6_nd.c
@@ -245,8 +245,7 @@ icmp6_neighbor_solicitation_or_advertisement (vlib_main_t * vm,
 	    {
 			if(error0 == ICMP6_ERROR_NONE &&
 				target_is_interface_local0 &&
-				(vnet_buffer2(p0)->lcp_host_copy_flags &
-				VNET_BUFFER_LCP_HOST_COPY_NDP)
+				vnet_buffer2(p0)->lcp_host_copy_done
 			){
 				error0 =
 					ICMP6_ERROR_NEIGHBOR_ADVERTISEMENT_SUPPRESSED_LINUX_OWNER;

--- a/ET2500/vpp-24.02/src/vnet/ip6-nd/ip6_nd.c
+++ b/ET2500/vpp-24.02/src/vnet/ip6-nd/ip6_nd.c
@@ -224,6 +224,7 @@ icmp6_neighbor_solicitation_or_advertisement (vlib_main_t * vm,
 			{
 			  /* It's one of our link local addresses
 			   * that's good. */
+			  target_is_interface_local0 = 1;
 			}
 		      else if (fib_entry_is_sourced (fei,
 						     FIB_SOURCE_IP6_ND_PROXY))


### PR DESCRIPTION
Prevent duplicate ARP Replies and IPv6 Neighbor Advertisements by using Linux as the reply owner.

- Added a shared 1-bit `lcp_host_copy_done` flag for ARP and NDP without increasing the VPP buffer size.
- Added an LCP pair check in `linux-cp-ndp-phy` before copying packets to Linux.
- Added local-interface target validation for NDP.
- Suppressed the VPP reply through a new error path after a valid NS is copied to Linux.
- Fixed NDP trace data copying to preserve `sw_if_index`.